### PR TITLE
fix: right operand array only for correct operators

### DIFF
--- a/src/app/cx-policy/components/policy-editor/policy-builder/permission/dialog/constraint-dialog/atomic.constraint.component.html
+++ b/src/app/cx-policy/components/policy-editor/policy-builder/permission/dialog/constraint-dialog/atomic.constraint.component.html
@@ -26,16 +26,31 @@ SPDX-License-Identifier: Apache-2.0
   </fieldset>
   <fieldset class="fieldset bg-base-300 border-base-300 rounded-box w-5xl border p-4">
     <legend class="fieldset-legend text-sm justify-start w-full"><span>Operator</span></legend>
-    <select
-      class="select select-bordered w-full"
-      [(ngModel)]="constraint.selectedOperator"
-      (change)="onOperatorChange()"
-      [disabled]="constraint.operator.length === 1"
-    >
-      @for (operator of constraint.operator; track operator) {
-        <option [value]="operator">{{ camelCaseToWords(operator, true) }}</option>
-      }
-    </select>
+    @if (operatorWarning) {
+      <div role="alert" class="alert alert-warning alert-horizontal">
+        <span class="material-symbols-rounded !text-3xl">warning</span>
+        <div>
+          <span>All right operands except the first will be deleted!</span>
+        </div>
+        <div>
+          <button type="button" class="btn btn-sm btn-outline hover:btn-error" (click)="resetToSingleItem()">
+            Accept
+          </button>
+          <button type="button" class="btn btn-sm ml-3" (click)="revertOperatorSelection()">Cancel</button>
+        </div>
+      </div>
+    } @else {
+      <select
+        class="select select-bordered w-full"
+        [(ngModel)]="constraint.selectedOperator"
+        (change)="onOperatorChange()"
+        [disabled]="constraint.operator.length === 1"
+      >
+        @for (operator of constraint.operator; track operator) {
+          <option [value]="operator">{{ camelCaseToWords(operator, true) }}</option>
+        }
+      </select>
+    }
   </fieldset>
   <fieldset class="fieldset w-5xl bg-base-300 border border-base-300 p-4 rounded-box" [formGroup]="form">
     <legend class="fieldset-legend text-sm justify-start w-full">Right Operand</legend>


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Closes #3 

The bug affects all constraints with `eq` operator that have multiple right operands to choose from. Therefore, with this PR, array for right operand is only available for operators `isAnyOf`, `isAllOf` and `isNoneOf`. 

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
