### PR TITLE
chore: configure dependabot grouped version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      npm-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      docker-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "gradle"
+    directory: "/cx-policy-validator"
+    schedule:
+      interval: "daily"
+    groups:
+      gradle-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

This PR configures Dependabot to automatically upgrade dependencies across `npm`, `gradle`, `docker`, and `github-actions` ecosystems.

It utilizes Dependabot's `groups` feature, which combines all outdated dependencies per ecosystem into a single PR, helping to keep the repository's dependencies up-to-date while avoiding PR spam.