### PR TITLE
fix: align policy type select indicator

### DIFF
--- a/src/app/cx-policy/components/policy-editor/policy-editor.component.html
+++ b/src/app/cx-policy/components/policy-editor/policy-editor.component.html
@@ -35,7 +35,7 @@ SPDX-License-Identifier: Apache-2.0
     } @else {
       <label class="select w-full">
         <span class="label">Select Policy Type</span>
-        <select class="select w-full" [(ngModel)]="selectedPolicyType" (ngModelChange)="onTypeChange()">
+        <select [(ngModel)]="selectedPolicyType" (ngModelChange)="onTypeChange()">
           <option [value]="Action.Access">Access Policy</option>
           <option [value]="Action.Use">Usage Policy</option>
         </select>


### PR DESCRIPTION
## Summary

Fixes the policy type selector indicator overlapping the selected option text.

## Problem

The policy type selector applied the DaisyUI `select` class to both the wrapper and the nested `<select>` element. This caused the indicator to overlap the selected policy type label.

## Change

Removed the redundant `select` styling from the nested `<select>` element.

The change is intentionally limited to the policy type selector and does not modify the surrounding layout or styling.

## Validation

- [x] Verified the selector manually
- [x] The selected value remains visible
- [x] The indicator is positioned correctly